### PR TITLE
fix: ignore HasDarkBackground error and use default value

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,11 +50,7 @@ sequin <file
 }
 
 func exec(w *colorprofile.Writer, in []byte) error {
-	hasDarkBG, err := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
-	if err != nil {
-		return err
-	}
-
+	hasDarkBG, _ := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
 	lightDark := lipgloss.LightDark(hasDarkBG)
 
 	rawKindStyle := lipgloss.NewStyle().


### PR DESCRIPTION
HasDarkBackground is a helper function that reads the background color of the terminal and returns a boolean indicating whether it is dark or light. When it fails, it returns a default value of _true_ indicating that the colors should be adjusted for a dark background if the terminal background color cannot be determined.