### PR TITLE
First bit of Tektronix support, also SGR 53/55 (overline)

### DIFF
--- a/mode.go
+++ b/mode.go
@@ -32,6 +32,8 @@ func modeDesc(mode int) string {
 		return "cursor keys"
 	case 25:
 		return "cursor visibility"
+	case 38:
+		return "tektronix mode"
 	case 1000:
 		return "show mouse"
 	case 1001:

--- a/sgr.go
+++ b/sgr.go
@@ -89,6 +89,10 @@ func handleSgr(parser *ansi.Parser) (string, error) { //nolint:unparam
 			str += fmt.Sprintf("Background color: %d", readColor(&i, parser.Params))
 		case 49:
 			str += "Default background color"
+		case 53:
+			str += "Overline"
+		case 55:
+			str += "No-overline"
 		case 58, 59:
 			str += fmt.Sprintf("Underline color: %d", readColor(&i, parser.Params))
 		case 90, 91, 92, 93, 94, 95, 96, 97:

--- a/sgr.go
+++ b/sgr.go
@@ -92,7 +92,7 @@ func handleSgr(parser *ansi.Parser) (string, error) { //nolint:unparam
 		case 53:
 			str += "Overline"
 		case 55:
-			str += "No-overline"
+			str += "No overline"
 		case 58, 59:
 			str += fmt.Sprintf("Underline color: %d", readColor(&i, parser.Params))
 		case 90, 91, 92, 93, 94, 95, 96, 97:


### PR DESCRIPTION
This adds a very initial support for VT-style Tektronix graphics ("CSI ?38h: Enable private mode "tektronix mode") and overline attribute support (I was learning my way around the code). Not sure how to add unit tests for those, however - might need help there