### PR TITLE
feat: support PM and SOS sequences

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -168,6 +168,8 @@ var others = map[string]string{
 	"esc":                          fmt.Sprintf("%c", ansi.ESC),
 	"file sep":                     fmt.Sprintf("%c", ansi.FS),
 	"apc":                          "\x1b_Hello World\x1b\\",
+	"pm":                           "\x1b^Hello World\x1b\\",
+	"sos":                          "\x1bXHello World\x1b\\",
 }
 
 var sgr = map[string]string{

--- a/testdata/TestSequences/others/pm.golden
+++ b/testdata/TestSequences/others/pm.golden
@@ -1,0 +1,1 @@
+  PM : Privacy message "Hello World"

--- a/testdata/TestSequences/others/sos.golden
+++ b/testdata/TestSequences/others/sos.golden
@@ -1,0 +1,1 @@
+ SOS : Control string "Hello World"

--- a/theme.go
+++ b/theme.go
@@ -19,7 +19,7 @@ type theme struct {
 	explanation lipgloss.Style
 
 	kindColors struct {
-		apc, csi, ctrl, dcs, esc, osc, text color.Color
+		apc, csi, ctrl, dcs, esc, osc, pm, sos, text color.Color
 	}
 }
 
@@ -37,6 +37,8 @@ func (t theme) kindStyle(kind string) lipgloss.Style {
 		"dcs":  base.Foreground(t.kindColors.dcs),
 		"esc":  base.Foreground(t.kindColors.esc),
 		"osc":  base.Foreground(t.kindColors.osc),
+		"pm":   base.Foreground(t.kindColors.pm),
+		"sos":  base.Foreground(t.kindColors.sos),
 		"text": base.Foreground(t.kindColors.text),
 	}[kind]
 
@@ -53,6 +55,10 @@ func (t theme) kindStyle(kind string) lipgloss.Style {
 		return s.SetString("OSC")
 	case "apc":
 		return s.SetString("APC")
+	case "pm":
+		return s.SetString("PM")
+	case "sos":
+		return s.SetString("SOS")
 	case "esc":
 		return s.SetString("ESC")
 	case "ctrl":
@@ -94,6 +100,8 @@ func charmTheme(hasDarkBG bool) (t theme) {
 	t.kindColors.dcs = lightDark("#86C867", "#CEE88A")
 	t.kindColors.esc = lipgloss.Color("#E46FDD")
 	t.kindColors.osc = lightDark("#43C7E0", "#1CD4F7")
+	t.kindColors.pm = lightDark("#FF8383", "#DC7272")
+	t.kindColors.sos = lightDark("#978692", "#6C6068")
 	t.kindColors.text = lightDark("#978692", "#6C6068")
 
 	return t
@@ -114,6 +122,8 @@ func base16Theme(_ bool) theme {
 	t.kindColors.dcs = lipgloss.Yellow
 	t.kindColors.esc = lipgloss.Magenta
 	t.kindColors.osc = lipgloss.Cyan
+	t.kindColors.pm = lipgloss.BrightRed
+	t.kindColors.sos = lipgloss.BrightBlack
 	t.kindColors.text = lipgloss.BrightBlack
 
 	return t


### PR DESCRIPTION
Add support for PM (Privacy Message) and SOS (Start of String) as defined in ECMA-48.

Colors for PM were chosen more or less arbitrarily. Colors of SOS are set identical to Text since SOS is practically unused (spare more appealing/distinct colors for eventual future stuff) and is designed to carry special class of strings, so it is somewhat close semantically to normal text.

Since both do not have any implementations (that I am aware of) with sub-parameters, their handling was placed directly in `process`, instead as part of handlers' maps.

Most terminals simply do not render text enclosed by PM or SOS. GNU `screen` uses PM for [its message line facility](https://www.gnu.org/software/screen/manual/html_node/Privacy-Message.html).

Example output:

```sh
λ echo -ne '\x1b^Private message\x1b\\Normal text\x1bXExample control string\x1b\\' | ./sequin
  PM : Privacy message "Private message"
Text Normal text
 SOS : Control string "Example control string"
```

![Screenshot_20241123_150652](https://github.com/user-attachments/assets/4a93cc44-adff-40c6-8036-211e73bed9ce)
![Screenshot_20241123_150743](https://github.com/user-attachments/assets/e255ad67-5644-4b8c-8b30-76bb0ee936e8)

