### PR TITLE
fix: make single ESC respect raw mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func process(w *colorprofile.Writer, in []byte) error {
 		case ansi.HasEscPrefix(seq):
 			flushPrint()
 
-			if len(seq) == 1 {
+			if len(seq) == 1 && !raw {
 				// just an ESC
 				_, _ = fmt.Fprintf(
 					w,


### PR DESCRIPTION
Custom code for handling standalone ESC was not checking for raw mode, resulting in a mangled output.

Currently:
```sh
λ echo -ne '\x1b[1minside raw mode\x1b' | ./sequin -r
\x1b[1minside raw modeESC: Escape

```
![Screenshot_20241123_153333](https://github.com/user-attachments/assets/983504f7-52ce-43bf-920f-97f989b89936)

After adding `raw` mode check:
```sh
λ echo -ne '\x1b[1minside raw mode\x1b\x1b\\ text continues' | ./sequin -r
\x1b[1minside raw mode\x1b\x1b\\ text continues
```
![Screenshot_20241123_153353](https://github.com/user-attachments/assets/fb6da940-3764-4a44-b749-c630627730a4)
