### PR TITLE
fix: match display of BEL, ST, DEL with other Ctrl

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -75,6 +75,10 @@ var dcsHandlers = map[int]handlerFn{
 var escHandler = map[int]handlerFn{
 	'7': printf("Save cursor"),
 	'8': printf("Restore cursor"),
+
+	// C0/7-bit ASCII variant of ST.
+	// C1/8-bit extended ASCII variant handled as Ctrl.
+	'\\': printf("String terminator"),
 }
 
 var (

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var c0c1 = map[string]string{
+	// c0
+	"c0":  fmt.Sprintf("%s", func() string {
+		var c0codes string
+		for controlCode := 0x00; controlCode <= 0x1f; controlCode++ {
+			c0codes = fmt.Sprintf("%s%c", c0codes, controlCode)
+		}
+		return c0codes
+	}()),
+	// c1
+	"c1":  fmt.Sprintf("%s", func() string {
+			var controlCode byte
+			c1codes := []byte("")
+			for controlCode = 0x80; controlCode <= 0x9f; controlCode++ {
+				// Skip DCS, SOS, CSI, OSC, PM, and APC
+				switch controlCode {
+				case ansi.DCS, ansi.SOS, ansi.CSI, ansi.OSC, ansi.PM, ansi.APC:
+					continue
+				}
+				c1codes = append(c1codes, controlCode)
+			}
+			return string(c1codes[:])
+		}()),
+}
+
+var ascii =  map[string]string{
+	// space and del
+	"ascii": fmt.Sprintf(" %c", ansi.DEL),
+}
+
 var cursor = map[string]string{
 	// cursor
 	"save":                         ansi.SaveCursor,
@@ -212,6 +242,8 @@ var clipboard = map[string]string{
 
 func TestSequences(t *testing.T) {
 	for name, table := range map[string]map[string]string{
+		"c0c1":      c0c1,
+		"ascii":     ascii,
 		"cursor":    cursor,
 		"screen":    screen,
 		"line":      line,

--- a/testdata/TestSequences/ascii/ascii.golden
+++ b/testdata/TestSequences/ascii/ascii.golden
@@ -1,0 +1,2 @@
+Text  
+Ctrl \x7f: Delete

--- a/testdata/TestSequences/c0c1/c0.golden
+++ b/testdata/TestSequences/c0c1/c0.golden
@@ -1,0 +1,32 @@
+Ctrl \x00: Null
+Ctrl \x01: Start of heading
+Ctrl \x02: Start of text
+Ctrl \x03: End of text
+Ctrl \x04: End of transmission
+Ctrl \x05: Enquiry
+Ctrl \x06: Acknowledge
+Ctrl \a: Bell
+Ctrl \b: Backspace
+Ctrl \t: Horizontal tab
+Ctrl \n: Line feed
+Ctrl \v: Vertical tab
+Ctrl \f: Form feed
+Ctrl \r: Carriage return
+Ctrl \x0e: Shift out
+Ctrl \x0f: Shift in
+Ctrl \x10: Data link escape
+Ctrl \x11: Device control 1
+Ctrl \x12: Device control 2
+Ctrl \x13: Device control 3
+Ctrl \x14: Device control 4
+Ctrl \x15: Negative acknowledge
+Ctrl \x16: Synchronous idle
+Ctrl \x17: End of transmission block
+Ctrl \x18: Cancel
+Ctrl \x19: End of medium
+Ctrl \x1a: Substitute
+Ctrl ESC: Escape
+Ctrl \x1c: File separator
+Ctrl \x1d: Group separator
+Ctrl \x1e: Record separator
+Ctrl \x1f: Unit separator

--- a/testdata/TestSequences/c0c1/c1.golden
+++ b/testdata/TestSequences/c0c1/c1.golden
@@ -1,0 +1,26 @@
+Ctrl \x80: Padding character
+Ctrl \x81: High octet preset
+Ctrl \x82: Break permitted here
+Ctrl \x83: No break here
+Ctrl \x84: Index
+Ctrl \x85: Next line
+Ctrl \x86: Start of selected area
+Ctrl \x87: End of selected area
+Ctrl \x88: Character tabulation set
+Ctrl \x89: Character tabulation with justification
+Ctrl \x8a: Line tabulation set
+Ctrl \x8b: Partial line forward
+Ctrl \x8c: Partial line backward
+Ctrl \x8d: Reverse line feed
+Ctrl \x8e: Single shift 2
+Ctrl \x8f: Single shift 3
+Ctrl \x91: Private use 1
+Ctrl \x92: Private use 2
+Ctrl \x93: Set transmit state
+Ctrl \x94: Cancel character
+Ctrl \x95: Message waiting
+Ctrl \x96: Start of guarded area
+Ctrl \x97: End of guarded area
+Ctrl \x99: Single graphic character introducer
+Ctrl \x9a: Single character introducer
+Ctrl \x9c: String terminator

--- a/testdata/TestSequences/screen/passthrough.golden
+++ b/testdata/TestSequences/screen/passthrough.golden
@@ -1,3 +1,3 @@
  DCS : TODO: unhandled sequence
  ESC 7: Save cursor
- ESC \\: TODO: unhandled sequence
+ ESC \\: String terminator


### PR DESCRIPTION
**Context**: This PR should align some minor inconsistencies in how some C0 and C1 characters are displayed.

Modify BEL, ST, and DEL labeling to match other Ctrl sequences:

  - Add missing label for DEL.
  - Fix BEL and C1 ST not having their hex code displayed when not part of a sequence
  - Handle ESC \\\\ (C0 ST)
  - Add tests for C0, C1, and misc ASCII (space and DEL)

```sh
λ echo -ne '\x1f\x7f\x9c\t\n\a\e\\' | ./sequin
Ctrl \x1f: Unit separator
Ctrl \x7f:
Ctrl : String terminator
Ctrl \t: Horizontal tab
Ctrl \n: Line feed
Ctrl : Bell
 ESC \\: TODO: unhandled sequence
```
![Screenshot_20241126_225628](https://github.com/user-attachments/assets/90e650a2-9d01-4e67-a7c0-f944edb7ddd5)

After changes:

```sh
λ echo -ne '\x1f\x7f\x9c\t\n\a\e\\' | ./sequin
Ctrl \x1f: Unit separator
Ctrl \x7f: Delete
Ctrl \x9c: String terminator
Ctrl \t: Horizontal tab
Ctrl \n: Line feed
Ctrl \a: Bell
 ESC \\: String terminator
```
![Screenshot_20241126_225649](https://github.com/user-attachments/assets/58b320c8-32fb-43e0-98d9-393f88e9ff3d)
