### PR TITLE
fix: remove doubled error message

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ var (
 
 func main() {
 	if err := cmd().Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Hi! A very minor issue. Unhandled errors are printed twice, once on stderr by cobra and for the second time in `main()` to stdout,

Useful link describing the behavior of built-in error printing in cobra: https://github.com/spf13/cobra/blob/main/site/content/user_guide.md#error-message-prefix

![Screenshot_20241129_222135](https://github.com/user-attachments/assets/a2ed5e2a-6c09-4aee-9084-d8f17709a8c5)
