### PR TITLE
fix(compat): more accurate behavior of SGR 21

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -180,7 +180,7 @@ var sgr = map[string]string{
 	"style 4":                      new(ansi.Style).BackgroundColor(ansi.BrightYellow).ForegroundColor(ansi.Black).UnderlineColor(ansi.BrightCyan).String(),
 	"style 5":                      new(ansi.Style).BackgroundColor(ansi.TrueColor(0xffeeaa)).ForegroundColor(ansi.TrueColor(0xffeeaa)).UnderlineColor(ansi.TrueColor(0xffeeaa)).String(),
 	"style 6":                      new(ansi.Style).BackgroundColor(ansi.ExtendedColor(255)).ForegroundColor(ansi.ExtendedColor(255)).UnderlineColor(ansi.ExtendedColor(255)).String(),
-	"style 7":                      new(ansi.Style).NoUnderline().NoBold().NoItalic().NormalIntensity().NoBlink().NoConceal().NoReverse().NoStrikethrough().String(),
+	"style 7":                      new(ansi.Style).NoUnderline().EcmaDoubleUnderline().NoItalic().NormalIntensity().NoBlink().NoConceal().NoReverse().NoStrikethrough().String(),
 	"style 8":                      new(ansi.Style).UnderlineStyle(ansi.NoUnderlineStyle).DefaultBackgroundColor().String(),
 	"style 9":                      strings.Replace(new(ansi.Style).UnderlineStyle(ansi.SingleUnderlineStyle).DefaultForegroundColor().String(), "[4", "[4:1", 1),
 	"style 10":                     new(ansi.Style).UnderlineStyle(ansi.DoubleUnderlineStyle).String(),

--- a/sgr.go
+++ b/sgr.go
@@ -65,7 +65,7 @@ func handleSgr(p *ansi.Parser) (string, error) { //nolint:unparam
 		case 9:
 			str += "Crossed-out"
 		case 21:
-			str += "No bold"
+			str += "Double underline"
 		case 22:
 			str += "Normal intensity"
 		case 23:

--- a/testdata/TestSequences/sgr/style_7.golden
+++ b/testdata/TestSequences/sgr/style_7.golden
@@ -1,1 +1,1 @@
- CSI 24;21;23;22;25;28;27;29m: No underline, No bold, No italic, Normal intensity, No blink, No conceal, No reverse, No crossed-out
+ CSI 24;21;23;22;25;28;27;29m: No underline, Double underline, No italic, Normal intensity, No blink, No conceal, No reverse, No crossed-out


### PR DESCRIPTION
Changes required if change for SGR 21 in `x/ansi` (https://github.com/charmbracelet/x/pull/309) accepted without further changes.

Adapts description of SGR 21 to match the most common implementation.

(Somewhat related to my related inquiry in https://github.com/charmbracelet/sequin/issues/27 about dealing with conflicting implementations).