### PR TITLE
feat: introduce optional mnemonics

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -14,23 +14,23 @@ var clipboardName = map[string]string{
 }
 
 //nolint:mnd
-func handleClipboard(p *ansi.Parser) (string, error) {
+func handleClipboard(p *ansi.Parser) (seqInfo, error) {
 	parts := bytes.Split(p.Data(), []byte{';'})
 	if len(parts) != 3 {
 		// Invalid, ignore
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 
 	if string(parts[2]) == "?" {
-		return fmt.Sprintf("Request %q clipboard", clipboardName[string(parts[1])]), nil
+		return seqNoMnemonic(fmt.Sprintf("Request %q clipboard", clipboardName[string(parts[1])])), nil
 	}
 
 	b64, err := base64.StdEncoding.DecodeString(string(parts[2]))
 	if err != nil {
 		// Invalid, ignore
 		//nolint:wrapcheck
-		return "", err
+		return seqNoMnemonic(""), err
 	}
 
-	return fmt.Sprintf("Set clipboard %q to %q", clipboardName[string(parts[1])], b64), nil
+	return seqNoMnemonic(fmt.Sprintf("Set clipboard %q to %q", clipboardName[string(parts[1])], b64)), nil
 }

--- a/color.go
+++ b/color.go
@@ -7,11 +7,11 @@ import (
 )
 
 //nolint:mnd
-func handleTerminalColor(p *ansi.Parser) (string, error) {
+func handleTerminalColor(p *ansi.Parser) (seqInfo, error) {
 	parts := bytes.Split(p.Data(), []byte{';'})
 	if len(parts) != 2 {
 		// Invalid, ignore
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 
 	arg := string(parts[1])
@@ -33,15 +33,15 @@ func handleTerminalColor(p *ansi.Parser) (string, error) {
 	if arg == "?" {
 		buf += " to " + arg
 	}
-	return buf, nil
+	return seqNoMnemonic(buf), nil
 }
 
 //nolint:mnd
-func handleResetTerminalColor(p *ansi.Parser) (string, error) {
+func handleResetTerminalColor(p *ansi.Parser) (seqInfo, error) {
 	parts := bytes.Split(p.Data(), []byte{';'})
 	if len(parts) != 1 {
 		// Invalid, ignore
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 	var buf string
 	switch p.Command() {
@@ -52,5 +52,5 @@ func handleResetTerminalColor(p *ansi.Parser) (string, error) {
 	case 112:
 		buf += "Reset cursor color"
 	}
-	return buf, nil
+	return seqNoMnemonic(buf), nil
 }

--- a/cursor.go
+++ b/cursor.go
@@ -7,7 +7,7 @@ import (
 )
 
 //nolint:mnd
-func handleCursor(p *ansi.Parser) (string, error) {
+func handleCursor(p *ansi.Parser) (seqInfo, error) {
 	count := 1
 	if n, ok := p.Param(0, 1); ok && n > 0 {
 		count = n
@@ -18,20 +18,38 @@ func handleCursor(p *ansi.Parser) (string, error) {
 	switch cmd.Final() {
 	case 'A':
 		// CUU - Cursor Up
-		return fmt.Sprintf("Cursor up %d", default1(count)), nil
+		return seqInfo{
+			"CUU",
+			fmt.Sprintf("Cursor up %d", default1(count)),
+		}, nil
 	case 'B':
 		// CUD - Cursor Down
-		return fmt.Sprintf("Cursor down %d", default1(count)), nil
+		return seqInfo{
+			"CUD",
+			fmt.Sprintf("Cursor down %d", default1(count)),
+		}, nil
 	case 'C':
 		// CUF - Cursor Forward
-		return fmt.Sprintf("Cursor right %d", default1(count)), nil
+		return seqInfo{
+			"CUF",
+			fmt.Sprintf("Cursor right %d", default1(count)),
+		}, nil
 	case 'D':
 		// CUB - Cursor Back
-		return fmt.Sprintf("Cursor left %d", default1(count)), nil
+		return seqInfo{
+			"CUB",
+			fmt.Sprintf("Cursor left %d", default1(count)),
+		}, nil
 	case 'E':
-		return fmt.Sprintf("Cursor next line %d", default1(count)), nil
+		return seqInfo{
+			"CNL",
+			fmt.Sprintf("Cursor next line %d", default1(count)),
+		}, nil
 	case 'F':
-		return fmt.Sprintf("Cursor previous line %d", default1(count)), nil
+		return seqInfo{
+			"CPL",
+			fmt.Sprintf("Cursor previous line %d", default1(count)),
+		}, nil
 	case 'H':
 		row, col := 1, 1
 		if n, ok := p.Param(0, 1); ok && n > 0 {
@@ -40,23 +58,32 @@ func handleCursor(p *ansi.Parser) (string, error) {
 		if n, ok := p.Param(1, 1); ok && n > 0 {
 			col = n
 		}
-		return fmt.Sprintf("Set cursor position row=%[1]d col=%[2]d", row, col), nil
+		return seqInfo{
+			"CUP",
+			fmt.Sprintf("Set cursor position row=%[1]d col=%[2]d", row, col),
+		}, nil
 	case 'n':
 		if count != 6 {
-			return "", errInvalid
+			return seqNoMnemonic(""), errInvalid
 		}
 		if isPrivate {
-			return "Request extended cursor position", nil
+			return seqInfo{
+				"DECXCPR",
+				"Request extended cursor position",
+			}, nil
 		}
-		return "Request cursor position", nil
+		return seqInfo{"CPR", "Request cursor position"}, nil
 	case 's':
-		return "Save cursor position", nil
+		return seqInfo{"SCOSC", "Save cursor position"}, nil
 	case 'u':
-		return "Restore cursor position", nil
+		return seqInfo{"SCORC", "Restore cursor position"}, nil
 	case 'q':
-		return fmt.Sprintf("Set cursor style %s", descCursorStyle(count)), nil
+		return seqInfo{
+			"DECSCUSR",
+			fmt.Sprintf("Set cursor style %s", descCursorStyle(count)),
+		}, nil
 	}
-	return "", errUnhandled
+	return seqNoMnemonic(""), errUnhandled
 }
 
 //nolint:mnd

--- a/cwd.go
+++ b/cwd.go
@@ -9,19 +9,19 @@ import (
 )
 
 //nolint:mnd
-func handleWorkingDirectoryURL(p *ansi.Parser) (string, error) {
+func handleWorkingDirectoryURL(p *ansi.Parser) (seqInfo, error) {
 	parts := bytes.Split(p.Data(), []byte{';'})
 	if len(parts) != 2 {
 		// Invalid, ignore
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 
 	u, err := url.ParseRequestURI(string(parts[1]))
 
 	if err != nil || u.Scheme != "file" {
 		// Should be a file URL.
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 
-	return fmt.Sprintf("Set working directory to %s (on %s)", u.Path, u.Host), nil
+	return seqNoMnemonic(fmt.Sprintf("Set working directory to %s (on %s)", u.Path, u.Host)), nil
 }

--- a/hyperlink.go
+++ b/hyperlink.go
@@ -8,11 +8,11 @@ import (
 )
 
 //nolint:mnd
-func handleHyperlink(p *ansi.Parser) (string, error) {
+func handleHyperlink(p *ansi.Parser) (seqInfo, error) {
 	parts := bytes.Split(p.Data(), []byte{';'})
 	if len(parts) != 3 {
 		// Invalid, ignore
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 
 	opts := bytes.Split(parts[1], []byte{':'})
@@ -25,5 +25,5 @@ func handleHyperlink(p *ansi.Parser) (string, error) {
 	}
 
 	buf += fmt.Sprintf(" to %q", parts[2])
-	return buf, nil
+	return seqNoMnemonic(buf), nil
 }

--- a/kitty.go
+++ b/kitty.go
@@ -8,7 +8,7 @@ import (
 )
 
 //nolint:mnd
-func handleKitty(p *ansi.Parser) (string, error) {
+func handleKitty(p *ansi.Parser) (seqInfo, error) {
 	flagDesc := func(flag int) string {
 		var r []string
 		if flag&1 != 0 {
@@ -49,18 +49,18 @@ func handleKitty(p *ansi.Parser) (string, error) {
 	cmd := ansi.Cmd(p.Command())
 	switch cmd.Prefix() {
 	case '?':
-		return "Request Kitty keyboard", nil
+		return seqNoMnemonic("Request Kitty keyboard"), nil
 	case '>':
 		if first == 0 {
-			return "Disable Kitty keyboard", nil
+			return seqNoMnemonic("Disable Kitty keyboard"), nil
 		}
-		return fmt.Sprintf("Push %q Kitty keyboard flag", flagDesc(first)), nil
+		return seqNoMnemonic(fmt.Sprintf("Push %q Kitty keyboard flag", flagDesc(first))), nil
 	case '<':
-		return fmt.Sprintf("Pop %d Kitty keyboard flags", first), nil
+		return seqNoMnemonic(fmt.Sprintf("Pop %d Kitty keyboard flags", first)), nil
 	case '=':
 		if n, ok := p.Param(1, 0); ok {
-			return fmt.Sprintf("Set %q Kitty keyboard flags to %q", flagDesc(first), modeDesc(n)), nil
+			return seqNoMnemonic(fmt.Sprintf("Set %q Kitty keyboard flags to %q", flagDesc(first), modeDesc(n))), nil
 		}
 	}
-	return "", errUnhandled
+	return seqNoMnemonic(""), errUnhandled
 }

--- a/line.go
+++ b/line.go
@@ -7,7 +7,7 @@ import (
 )
 
 //nolint:mnd
-func handleLine(p *ansi.Parser) (string, error) {
+func handleLine(p *ansi.Parser) (seqInfo, error) {
 	var count int
 	if n, ok := p.Param(0, 0); ok {
 		count = n
@@ -15,22 +15,23 @@ func handleLine(p *ansi.Parser) (string, error) {
 
 	switch p.Command() {
 	case 'K':
+		mnemonic := "EL"
 		switch count {
 		case 0:
-			return "Erase line right", nil
+			return seqInfo{mnemonic, "Erase line right"}, nil
 		case 1:
-			return "Erase line left", nil
+			return seqInfo{mnemonic, "Erase line left"}, nil
 		case 2:
-			return "Erase entire line", nil
+			return seqInfo{mnemonic, "Erase entire line"}, nil
 		}
 	case 'L':
-		return fmt.Sprintf("Insert %d blank lines", default1(count)), nil
+		return seqInfo{"IL", fmt.Sprintf("Insert %d blank lines", default1(count))}, nil
 	case 'M':
-		return fmt.Sprintf("Delete %d lines", default1(count)), nil
+		return seqInfo{"DL", fmt.Sprintf("Delete %d lines", default1(count))}, nil
 	case 'S':
-		return fmt.Sprintf("Scroll up %d lines", default1(count)), nil
+		return seqInfo{"SU", fmt.Sprintf("Scroll up %d lines", default1(count))}, nil
 	case 'T':
-		return fmt.Sprintf("Scroll down %d lines", default1(count)), nil
+		return seqInfo{"SD", fmt.Sprintf("Scroll down %d lines", default1(count))}, nil
 	}
-	return "", errUnhandled
+	return seqNoMnemonic(""), errUnhandled
 }

--- a/main_test.go
+++ b/main_test.go
@@ -243,6 +243,21 @@ var clipboard = map[string]string{
 	"invalid":         strings.Replace(ansi.SetPrimaryClipboard("hello"), "=", "", 1),
 }
 
+var sequinFlags = map[string]string{
+	"raw":       fmt.Sprintf("%s%s%s%s",
+			"\x1bXflag feature test\x1b\\",
+			strings.Replace(ansi.ResetStyle, "m", "0m", 1),
+			"Raw mode\n",
+			ansi.EraseLineRight,
+		),
+	"mnemonics": fmt.Sprintf("%s%s%s%s",
+			"\x1bXflag feature test\x1b\\",
+			strings.Replace(ansi.ResetStyle, "m", "0m", 1),
+			"Mnemonics\n",
+			ansi.EraseLineRight,
+		),
+}
+
 func TestSequences(t *testing.T) {
 	for name, table := range map[string]map[string]string{
 		"c0c1":      c0c1,
@@ -270,6 +285,25 @@ func TestSequences(t *testing.T) {
 					cmd.SetErr(&b)
 					cmd.SetIn(strings.NewReader(input))
 					cmd.SetArgs([]string{})
+					require.NoError(t, cmd.Execute())
+					golden.RequireEqual(t, b.Bytes())
+				})
+			}
+		})
+	}
+
+	for name, table := range map[string]map[string]string{
+		"sequinflags": sequinFlags,
+	} {
+		t.Run(name, func(t *testing.T) {
+			for name, input := range table {
+				t.Run(name, func(t *testing.T) {
+					var b bytes.Buffer
+					cmd := cmd()
+					cmd.SetOut(&b)
+					cmd.SetErr(&b)
+					cmd.SetIn(strings.NewReader(input))
+					cmd.SetArgs([]string{fmt.Sprintf("--%s", name) })
 					require.NoError(t, cmd.Execute())
 					golden.RequireEqual(t, b.Bytes())
 				})

--- a/mode.go
+++ b/mode.go
@@ -6,7 +6,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-func handleMode(p *ansi.Parser) (string, error) {
+func handleMode(p *ansi.Parser) (seqInfo, error) {
 	var m int
 	if n, ok := p.Param(0, 0); ok {
 		m = n
@@ -20,13 +20,34 @@ func handleMode(p *ansi.Parser) (string, error) {
 	switch cmd.Final() {
 	case 'p':
 		// DECRQM - Request Mode
-		return fmt.Sprintf("Request %smode %q", private, mode), nil
+		return seqInfo{
+			"DECRQM",
+			fmt.Sprintf("Request %smode %q", private, mode),
+		}, nil
 	case 'h':
-		return fmt.Sprintf("Enable %smode %q", private, mode), nil
+		var mnemonic string
+		if cmd.Prefix() == '?' {
+			mnemonic = "DECSET"
+		} else {
+			mnemonic = "SM"
+		}
+		return seqInfo{
+			mnemonic,
+			fmt.Sprintf("Enable %smode %q", private, mode),
+		}, nil
 	case 'l':
-		return fmt.Sprintf("Disable %smode %q", private, mode), nil
+		var mnemonic string
+		if cmd.Prefix() == '?' {
+			mnemonic = "DECRST"
+		} else {
+			mnemonic = "RM"
+		}
+		return seqInfo{
+			mnemonic,
+			fmt.Sprintf("Disable %smode %q", private, mode),
+		}, nil
 	}
-	return "", errUnhandled
+	return seqNoMnemonic(""), errUnhandled
 }
 
 //nolint:mnd

--- a/notify.go
+++ b/notify.go
@@ -8,12 +8,12 @@ import (
 )
 
 //nolint:mnd
-func handleNotify(p *ansi.Parser) (string, error) {
+func handleNotify(p *ansi.Parser) (seqInfo, error) {
 	parts := bytes.Split(p.Data(), []byte{';'})
 	if len(parts) != 2 {
 		// Invalid, ignore
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 
-	return fmt.Sprintf("Notify %q", parts[1]), nil
+	return seqNoMnemonic(fmt.Sprintf("Notify %q", parts[1])), nil
 }

--- a/pointer.go
+++ b/pointer.go
@@ -8,12 +8,12 @@ import (
 )
 
 //nolint:mnd
-func handlePointerShape(p *ansi.Parser) (string, error) {
+func handlePointerShape(p *ansi.Parser) (seqInfo, error) {
 	parts := bytes.Split(p.Data(), []byte{';'})
 	if len(parts) != 2 {
 		// Invalid, ignore
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 
-	return fmt.Sprintf("Set pointer shape to %q", parts[1]), nil
+	return seqNoMnemonic(fmt.Sprintf("Set pointer shape to %q", parts[1])), nil
 }

--- a/screen.go
+++ b/screen.go
@@ -7,7 +7,7 @@ import (
 )
 
 //nolint:mnd
-func handleScreen(p *ansi.Parser) (string, error) {
+func handleScreen(p *ansi.Parser) (seqInfo, error) {
 	var count int
 	if n, ok := p.Param(0, 0); ok {
 		count = n
@@ -16,15 +16,16 @@ func handleScreen(p *ansi.Parser) (string, error) {
 	cmd := ansi.Cmd(p.Command())
 	switch cmd.Final() {
 	case 'J':
+		mnemonic := "ED"
 		switch count {
 		case 0:
-			return "Erase screen bellow", nil
+			return seqInfo{mnemonic, "Erase screen bellow"}, nil
 		case 1:
-			return "Erase screen above", nil
+			return seqInfo{mnemonic, "Erase screen above"}, nil
 		case 2:
-			return "Erase entire screen", nil
+			return seqInfo{mnemonic, "Erase entire screen"}, nil
 		case 3:
-			return "Erase entire display", nil
+			return seqInfo{mnemonic, "Erase entire display"}, nil
 		}
 	case 'r':
 		top, bot := 1, 0
@@ -34,12 +35,12 @@ func handleScreen(p *ansi.Parser) (string, error) {
 		if n, ok := p.Param(1, 0); ok {
 			bot = n
 		}
-		return fmt.Sprintf(
+		return seqInfo{"DECSTBM", fmt.Sprintf(
 			"Set scrolling region to top=%d bottom=%d",
 			top,
 			bot,
-		), nil
+		)}, nil
 	}
 
-	return "", errUnhandled
+	return seqNoMnemonic(""), errUnhandled
 }

--- a/sgr.go
+++ b/sgr.go
@@ -9,10 +9,11 @@ import (
 )
 
 //nolint:mnd
-func handleSgr(p *ansi.Parser) (string, error) { //nolint:unparam
+func handleSgr(p *ansi.Parser) (seqInfo, error) { //nolint:unparam
 	params := p.Params()
+	mnemonic := "SGR"
 	if len(params) == 0 {
-		return "Reset style", nil
+		return seqInfo{mnemonic, "Reset style"}, nil
 	}
 
 	var str string
@@ -106,7 +107,7 @@ func handleSgr(p *ansi.Parser) (string, error) { //nolint:unparam
 		}
 	}
 
-	return str, nil
+	return seqInfo{mnemonic, str}, nil
 }
 
 var basicColors = map[int]string{

--- a/termcap.go
+++ b/termcap.go
@@ -9,15 +9,15 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-func handleTermcap(p *ansi.Parser) (string, error) {
+func handleTermcap(p *ansi.Parser) (seqInfo, error) {
 	data := p.Data()
 	if len(data) == 0 {
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 
 	parts := bytes.Split(data, []byte{';'})
 	if len(parts) == 0 {
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 
 	caps := make([]string, 0, len(parts))
@@ -25,10 +25,13 @@ func handleTermcap(p *ansi.Parser) (string, error) {
 		capName, err := hex.DecodeString(string(part))
 		if err != nil {
 			//nolint:wrapcheck
-			return "", err
+			return seqNoMnemonic(""), err
 		}
 		caps = append(caps, string(capName))
 	}
 
-	return fmt.Sprintf("Request termcap entry for %s", strings.Join(caps, ", ")), nil
+	return seqInfo{
+		"XTGETTCAP",
+		fmt.Sprintf("Request termcap entry for %s", strings.Join(caps, ", ")),
+	}, nil
 }

--- a/testdata/TestSequences/sequinflags/mnemonics.golden
+++ b/testdata/TestSequences/sequinflags/mnemonics.golden
@@ -1,0 +1,5 @@
+ SOS : Control string "flag feature test"
+ CSI 0m: <SGR> Reset style
+Text Mnemonics
+Ctrl \n: <LF> Line feed
+ CSI K: <EL> Erase line right

--- a/testdata/TestSequences/sequinflags/raw.golden
+++ b/testdata/TestSequences/sequinflags/raw.golden
@@ -1,0 +1,1 @@
+\x1bXflag feature test\x1b\\\x1b[0mRaw mode\n\x1b[K

--- a/theme.go
+++ b/theme.go
@@ -17,6 +17,7 @@ type theme struct {
 	text        lipgloss.Style
 	error       lipgloss.Style
 	explanation lipgloss.Style
+	mnemonic    lipgloss.Style
 
 	kindColors struct {
 		apc, csi, ctrl, dcs, esc, osc, pm, sos, text color.Color
@@ -93,6 +94,7 @@ func charmTheme(hasDarkBG bool) (t theme) {
 		Foreground(lightDark("#EC6A88", "#ff5f87"))
 	t.explanation = lipgloss.NewStyle().
 		Foreground(lightDark("#3C343A", "#D4CAD1"))
+	t.mnemonic = t.explanation.Bold(true)
 
 	t.kindColors.apc = lightDark("#F58855", "#FF8383")
 	t.kindColors.csi = lightDark("#936EE5", "#8D58FF")
@@ -115,6 +117,7 @@ func base16Theme(_ bool) theme {
 	t.text = t.text.Foreground(lipgloss.BrightBlack)
 	t.error = t.error.Foreground(lipgloss.BrightRed)
 	t.explanation = t.explanation.Foreground(lipgloss.White)
+	t.mnemonic = t.explanation.Bold(true)
 
 	t.kindColors.apc = lipgloss.Red
 	t.kindColors.csi = lipgloss.Blue

--- a/title.go
+++ b/title.go
@@ -8,19 +8,19 @@ import (
 )
 
 //nolint:mnd
-func handleTitle(p *ansi.Parser) (string, error) {
+func handleTitle(p *ansi.Parser) (seqInfo, error) {
 	parts := bytes.Split(p.Data(), []byte{';'})
 	if len(parts) != 2 {
 		// Invalid, ignore
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 	switch p.Command() {
 	case 0:
-		return fmt.Sprintf("Set icon name and window title to %q", parts[1]), nil
+		return seqNoMnemonic(fmt.Sprintf("Set icon name and window title to %q", parts[1])), nil
 	case 1:
-		return fmt.Sprintf("Set icon name to %q", parts[1]), nil
+		return seqNoMnemonic(fmt.Sprintf("Set icon name to %q", parts[1])), nil
 	case 2:
-		return fmt.Sprintf("Set window title to %q", parts[1]), nil
+		return seqNoMnemonic(fmt.Sprintf("Set window title to %q", parts[1])), nil
 	}
-	return "", errUnhandled
+	return seqNoMnemonic(""), errUnhandled
 }

--- a/xt.go
+++ b/xt.go
@@ -2,15 +2,15 @@ package main
 
 import "github.com/charmbracelet/x/ansi"
 
-func handleXT(p *ansi.Parser) (string, error) {
+func handleXT(p *ansi.Parser) (seqInfo, error) {
 	var count int
 	if n, ok := p.Param(0, 0); ok {
 		count = n
 	}
 
 	if count != 0 {
-		return "", errInvalid
+		return seqNoMnemonic(""), errInvalid
 	}
 
-	return "Request XT Version", nil
+	return seqInfo{"XTVERSION", "Request XT Version"}, nil
 }


### PR DESCRIPTION
(probably a little too over-engineered)

Add option to display established mnemonics for well-known escape sequences to make it easier to search for more information.

  * introduce ECMA-48, DEC, and Xterm mnemonics
  * add `--mnemonics`,`-m` flags
  * add tests for output changed by flags (raw and mnemonics)
  * pass sequence data with `seqInfo` to handle multiple types of info per one sequence

**Further details:**
The optional flag adds `<MNEMONIC>` between the dissected contents of the sequence and the explanation. Not displayed in situations like `Text` or sequences without mnemonic and when sequence's type is the same as the mnemonic (SOS, PM, …).

I believe the current PR introduces mnemonics to all currently handled sequences that have one.

**Example:**
![Screenshot_20250309_164142](https://github.com/user-attachments/assets/ab44b02d-22c6-4cb8-aa56-43cff7c9f745)
