### PR TITLE
feat: handle multiple private modes in a single sequence

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -137,6 +137,12 @@ var mode = map[string]string{
 	"enable win32 input":          ansi.SetModeWin32Input,
 	"disable win32 input":         ansi.ResetModeWin32Input,
 	"request win32 input":         ansi.RequestModeWin32Input,
+	"enable mouse urxvt":          ansi.SetModeMouseExtUrxvt,
+	"disable mouse urxvt":         ansi.ResetModeMouseExtUrxvt,
+	"request mouse urxvt":         ansi.RequestModeMouseExtUrxvt,
+	"enable mouse multi":          "\x1b[?1000;1006;1015h",
+	"disable mouse multi":         "\x1b[?1000;1006l",
+	"request mouse multi":         "\x1b[?1000;1006$p",
 	"invalid":                     strings.Replace(ansi.SetModeTextCursorEnable, "25", "27", 1),
 	"non private":                 strings.Replace(ansi.SetModeTextCursorEnable, "?", "", 1),
 }

--- a/mode.go
+++ b/mode.go
@@ -2,29 +2,37 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/x/ansi"
 )
 
 func handleMode(p *ansi.Parser) (string, error) {
-	var m int
-	if n, ok := p.Param(0, 0); ok {
-		m = n
+	params := p.Params()
+	if len(params) == 0 {
+		return "", errUnhandled
 	}
-	mode := modeDesc(m)
+
 	cmd := ansi.Cmd(p.Command())
 	private := ""
 	if cmd.Prefix() == '?' {
 		private = "private "
 	}
+
+	var modes []string
+	for _, param := range params {
+		modes = append(modes, modeDesc(param.Param(0)))
+	}
+
+	desc := strings.Join(modes, ", ")
 	switch cmd.Final() {
 	case 'p':
 		// DECRQM - Request Mode
-		return fmt.Sprintf("Request %smode %q", private, mode), nil
+		return fmt.Sprintf("Request %smode %q", private, desc), nil
 	case 'h':
-		return fmt.Sprintf("Enable %smode %q", private, mode), nil
+		return fmt.Sprintf("Enable %smode %q", private, desc), nil
 	case 'l':
-		return fmt.Sprintf("Disable %smode %q", private, mode), nil
+		return fmt.Sprintf("Disable %smode %q", private, desc), nil
 	}
 	return "", errUnhandled
 }
@@ -48,6 +56,8 @@ func modeDesc(mode int) string {
 		return "report focus"
 	case 1006:
 		return "mouse SGR ext"
+	case 1015:
+		return "mouse URXVT ext"
 	case 1049:
 		return "altscreen"
 	case 2004:

--- a/testdata/TestSequences/mode/disable_mouse_multi.golden
+++ b/testdata/TestSequences/mode/disable_mouse_multi.golden
@@ -1,0 +1,1 @@
+ CSI ?1000;1006l: Disable private mode "show mouse, mouse SGR ext"

--- a/testdata/TestSequences/mode/disable_mouse_urxvt.golden
+++ b/testdata/TestSequences/mode/disable_mouse_urxvt.golden
@@ -1,0 +1,1 @@
+ CSI ?1015l: Disable private mode "mouse URXVT ext"

--- a/testdata/TestSequences/mode/enable_mouse_multi.golden
+++ b/testdata/TestSequences/mode/enable_mouse_multi.golden
@@ -1,0 +1,1 @@
+ CSI ?1000;1006;1015h: Enable private mode "show mouse, mouse SGR ext, mouse URXVT ext"

--- a/testdata/TestSequences/mode/enable_mouse_urxvt.golden
+++ b/testdata/TestSequences/mode/enable_mouse_urxvt.golden
@@ -1,0 +1,1 @@
+ CSI ?1015h: Enable private mode "mouse URXVT ext"

--- a/testdata/TestSequences/mode/request_mouse_multi.golden
+++ b/testdata/TestSequences/mode/request_mouse_multi.golden
@@ -1,0 +1,1 @@
+ CSI ?1000;1006$p: Request private mode "show mouse, mouse SGR ext"

--- a/testdata/TestSequences/mode/request_mouse_urxvt.golden
+++ b/testdata/TestSequences/mode/request_mouse_urxvt.golden
@@ -1,0 +1,1 @@
+ CSI ?1015$p: Request private mode "mouse URXVT ext"


### PR DESCRIPTION
## What

When a sequence like `\x1b[?1000;1006;1015h` is parsed, only the first mode (1000) was described — the remaining modes were silently ignored.

## How

Changed `handleMode` to iterate over all params from `p.Params()` instead of reading only `p.Param(0, 0)`. All mode descriptions are now joined with `, `:

```
Before: CSI ?1000;1006;1015h: Enable private mode "show mouse"
After:  CSI ?1000;1006;1015h: Enable private mode "show mouse, mouse SGR ext, mouse URXVT ext"
```

Also adds mode **1015** (URXVT mouse extension) to `modeDesc`, which was missing.

## Tests

- Added golden tests for single-mode 1015 (enable/disable/request)
- Added golden tests for multi-mode sequences (2 and 3 params)
- All existing tests pass unchanged

Fixes #98