### PR TITLE
feat: handle soft terminal reset (DECSTR) sequence

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -41,6 +41,7 @@ var csiHandlers = map[int]handlerFn{
 	'T': handleLine,
 
 	// modes
+	'p' | '!'<<intermedShift:                    printf("Soft Terminal Reset"),
 	'p' | '$'<<intermedShift:                    handleMode,
 	'p' | '?'<<markerShift | '$'<<intermedShift: handleMode,
 	'h' | '?'<<markerShift:                      handleMode,

--- a/main_test.go
+++ b/main_test.go
@@ -170,6 +170,7 @@ var others = map[string]string{
 	"apc":                          "\x1b_Hello World\x1b\\",
 	"pm":                           "\x1b^Hello World\x1b\\",
 	"sos":                          "\x1bXHello World\x1b\\",
+	"soft reset":                   "\x1b[!p",
 }
 
 var sgr = map[string]string{

--- a/testdata/TestSequences/others/soft_reset.golden
+++ b/testdata/TestSequences/others/soft_reset.golden
@@ -1,0 +1,1 @@
+ CSI !p: Soft Terminal Reset


### PR DESCRIPTION
Resolves #77

This PR adds support for parsing and explaining the `DECSTR` (DEC Soft Reset) sequence (`CSI !p`), which is commonly sent as part of `tput rs2`.

- Added the `CSI !p` handler mapping to output `Soft Terminal Reset`.
- Added a corresponding test case in `main_test.go` and updated the golden files.
- The other sequence mentioned in #77 (`ESC >` / Normal Keypad) appears to have already been resolved.