### PR TITLE
feat(mode): support multiple modes in one sequence

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -139,6 +139,7 @@ var mode = map[string]string{
 	"request win32 input":         ansi.RequestModeWin32Input,
 	"invalid":                     strings.Replace(ansi.SetModeTextCursorEnable, "25", "27", 1),
 	"non private":                 strings.Replace(ansi.SetModeTextCursorEnable, "?", "", 1),
+	"enable multiple modes":       "\x1b[?1000;1006;1015h",
 }
 
 var kitty = map[string]string{

--- a/mode.go
+++ b/mode.go
@@ -2,31 +2,43 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/x/ansi"
 )
 
 func handleMode(p *ansi.Parser) (string, error) {
-	var m int
-	if n, ok := p.Param(0, 0); ok {
-		m = n
+	params := p.Params()
+	if len(params) == 0 {
+		return "", errInvalid
 	}
-	mode := modeDesc(m)
+
 	cmd := ansi.Cmd(p.Command())
 	private := ""
 	if cmd.Prefix() == '?' {
 		private = "private "
 	}
+
+	var action string
 	switch cmd.Final() {
 	case 'p':
 		// DECRQM - Request Mode
-		return fmt.Sprintf("Request %smode %q", private, mode), nil
+		action = "Request"
 	case 'h':
-		return fmt.Sprintf("Enable %smode %q", private, mode), nil
+		action = "Enable"
 	case 'l':
-		return fmt.Sprintf("Disable %smode %q", private, mode), nil
+		action = "Disable"
+	default:
+		return "", errUnhandled
 	}
-	return "", errUnhandled
+
+	var modes []string
+	for _, param := range params {
+		m := param.Param(0)
+		modes = append(modes, fmt.Sprintf("%q", modeDesc(m)))
+	}
+
+	return fmt.Sprintf("%s %smode %s", action, private, strings.Join(modes, ", ")), nil
 }
 
 //nolint:mnd
@@ -48,6 +60,8 @@ func modeDesc(mode int) string {
 		return "report focus"
 	case 1006:
 		return "mouse SGR ext"
+	case 1015:
+		return "mouse URXVT ext"
 	case 1049:
 		return "altscreen"
 	case 2004:

--- a/testdata/TestSequences/mode/enable_multiple_modes.golden
+++ b/testdata/TestSequences/mode/enable_multiple_modes.golden
@@ -1,0 +1,1 @@
+ CSI ?1000;1006;1015h: Enable private mode "show mouse", "mouse SGR ext", "mouse URXVT ext"


### PR DESCRIPTION
Resolves #98

This PR adds support for parsing and explaining multiple private/standard modes toggled within the same sequence (delimited by semicolons), e.g. `\x1b[?1000;1006;1015h`.

### Changes
- Updated `handleMode` in `mode.go` to iterate over all parameters parsed from the sequence.
- Instead of describing only the first mode, it now aggregates descriptions of all modes, e.g. `Enable private mode "show mouse", "mouse SGR ext", "mouse URXVT ext"`.
- Added support for mode `1015` (`mouse URXVT ext`).
- Added test case and updated golden files.